### PR TITLE
Gantry Tilt Correction.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: divest
 Version: 0.1.2
-Date: 2016-12-16
+Date: 2016-01-10
 Title: Get Images Out of DICOM Format Quickly
 Author: Jon Clayden, based on dcm2niix by Chris Rorden
 Maintainer: Jon Clayden <code@clayden.org>
@@ -15,4 +15,4 @@ License: BSD_3_clause + file LICENCE
 URL: https://github.com/jonclayden/divest
 BugReports: https://github.com/jonclayden/divest/issues
 Encoding: UTF-8
-RoxygenNote: 5.0.1
+RoxygenNote: 5.0.1.9000

--- a/R/read.R
+++ b/R/read.R
@@ -18,6 +18,7 @@ sortInfoTable <- function (table)
 #'   orientation conventions in the DICOM and NIfTI-1 formats.
 #' @param verbosity Integer value between 0 and 3, controlling the amount of
 #'   output generated during the conversion.
+#' @param tiltCorrect Gantry tilt correction for CT scans.
 #' @param interactive If \code{TRUE}, the default in interactive sessions, the
 #'   requested paths will first be scanned and a list of DICOM series will be
 #'   presented. You may then choose which series to convert.
@@ -33,7 +34,9 @@ sortInfoTable <- function (table)
 #' readDicom(path, interactive=FALSE)
 #' @author Jon Clayden <code@@clayden.org>
 #' @export
-readDicom <- function (path = ".", flipY = TRUE, verbosity = 0L, interactive = base::interactive())
+readDicom <- function (path = ".", flipY = TRUE, 
+                       verbosity = 0L, tiltCorrect = FALSE,
+                       interactive = base::interactive())
 {
     readFromTempDirectory <- function (tempDirectory, files)
     {
@@ -59,14 +62,14 @@ readDicom <- function (path = ".", flipY = TRUE, verbosity = 0L, interactive = b
         if (!all(success))
             stop("Cannot symlink or copy files into temporary directory")
         
-        .Call("readDirectory", tempDirectory, flipY, verbosity, FALSE, PACKAGE="divest")
+        .Call("readDirectory", tempDirectory, flipY, verbosity, FALSE, tiltCorrect, PACKAGE="divest")
     }
     
     results <- lapply(path, function(p) {
         if (interactive)
         {
             p <- path.expand(p)
-            info <- sortInfoTable(.Call("readDirectory", p, flipY, 0L, TRUE, PACKAGE="divest"))
+            info <- sortInfoTable(.Call("readDirectory", p, flipY, 0L, TRUE, tiltCorrect, PACKAGE="divest"))
             
             nSeries <- nrow(info)
             if (nSeries < 1)
@@ -93,7 +96,7 @@ readDicom <- function (path = ".", flipY = TRUE, verbosity = 0L, interactive = b
             }
         }
         else
-            .Call("readDirectory", path.expand(p), flipY, verbosity, FALSE, PACKAGE="divest")
+            .Call("readDirectory", path.expand(p), flipY, verbosity, FALSE, tiltCorrect, PACKAGE="divest")
     })
     
     return (do.call(c, results))
@@ -103,6 +106,6 @@ readDicom <- function (path = ".", flipY = TRUE, verbosity = 0L, interactive = b
 #' @export
 scanDicom <- function (path = ".", verbosity = 0L)
 {
-    results <- lapply(path, function(p) .Call("readDirectory", path.expand(p), TRUE, verbosity, TRUE, PACKAGE="divest"))
+    results <- lapply(path, function(p) .Call("readDirectory", path.expand(p), TRUE, verbosity, TRUE, FALSE, PACKAGE="divest"))
     sortInfoTable(do.call(rbind, results))
 }

--- a/R/read.R
+++ b/R/read.R
@@ -104,8 +104,8 @@ readDicom <- function (path = ".", flipY = TRUE,
 
 #' @rdname readDicom
 #' @export
-scanDicom <- function (path = ".", verbosity = 0L)
+scanDicom <- function (path = ".", verbosity = 0L, tiltCorrect = FALSE)
 {
-    results <- lapply(path, function(p) .Call("readDirectory", path.expand(p), TRUE, verbosity, TRUE, FALSE, PACKAGE="divest"))
+    results <- lapply(path, function(p) .Call("readDirectory", path.expand(p), TRUE, verbosity, TRUE, tiltCorrect, PACKAGE="divest"))
     sortInfoTable(do.call(rbind, results))
 }

--- a/man/readDicom.Rd
+++ b/man/readDicom.Rd
@@ -5,14 +5,14 @@
 \alias{scanDicom}
 \title{Read one or more DICOM directories}
 \usage{
-readDicom(path, flipY = TRUE, verbosity = 0L,
+readDicom(path = ".", flipY = TRUE, verbosity = 0L, tiltCorrect = FALSE,
   interactive = base::interactive())
 
-scanDicom(path, verbosity = 0L)
+scanDicom(path = ".", verbosity = 0L)
 }
 \arguments{
 \item{path}{A character vector of paths to scan for DICOM files. Each will
-examined in turn.}
+examined in turn. The default is the current working directory.}
 
 \item{flipY}{If \code{TRUE}, the default, then images will be flipped in the
 Y-axis. This is usually desirable, given the difference between
@@ -20,6 +20,8 @@ orientation conventions in the DICOM and NIfTI-1 formats.}
 
 \item{verbosity}{Integer value between 0 and 3, controlling the amount of
 output generated during the conversion.}
+
+\item{tiltCorrect}{Gantry tilt correction for CT scans.}
 
 \item{interactive}{If \code{TRUE}, the default in interactive sessions, the
 requested paths will first be scanned and a list of DICOM series will be
@@ -46,4 +48,3 @@ readDicom(path, interactive=FALSE)
 \author{
 Jon Clayden <code@clayden.org>
 }
-

--- a/src/dcm2niix/nii_dicom_batch.cpp
+++ b/src/dcm2niix/nii_dicom_batch.cpp
@@ -1615,9 +1615,10 @@ int saveDcm2Nii(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dcmLis
     if (dcmList[indx0].gantryTilt != 0.0) {
         if (dcmList[indx0].isResampled)
             printMessage("Tilt correction skipped: 0008,2111 reports RESAMPLED\n");
-        else if (opts.isTiltCorrect)
+        else if (opts.isTiltCorrect) {
             imgM = nii_saveNII3Dtilt(pathoutname, &hdr0, imgM,opts, sliceMMarray, dcmList[indx0].gantryTilt, dcmList[indx0].manufacturer);
-        else
+            strcat(pathoutname, "_Tilt");
+        } else
             printMessage("Tilt correction skipped\n");
     }
     if (sliceMMarray != NULL) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ BEGIN_RCPP
             const int n = options.series.size();
             CharacterVector seriesDescription(n,NA_STRING), patientName(n,NA_STRING), descriptions(n);
             DateVector studyDate(n);
-            NumericVector echoTime(n,NA_REAL), repetitionTime(n,NA_REAL);
+            NumericVector echoTime(n,NA_REAL), repetitionTime(n,NA_REAL), gantryTilt(n, NA_REAL);
             IntegerVector seriesNumber(n,NA_INTEGER), echoNumber(n,NA_INTEGER);
             LogicalVector phase(n,NA_LOGICAL);
             List paths(n);
@@ -94,6 +94,9 @@ BEGIN_RCPP
                     description << ", TR " << data.TR << " ms";
                     repetitionTime[i] = data.TR;
                 }
+                if (data.gantryTilt != 0)
+                    description << ", gantryTilt " << data.gantryTilt;
+                    // gantryTilt[i] = data.gantryTilt;
                 if (data.echoNum > 0)
                     echoNumber[i] = data.echoNum;
                 if (data.echoNum > 1)
@@ -106,7 +109,7 @@ BEGIN_RCPP
                 paths[i] = wrap(options.series[i].files);
             }
             
-            DataFrame info = DataFrame::create(Named("rootPath")=path, Named("seriesNumber")=seriesNumber, Named("seriesDescription")=seriesDescription, Named("patientName")=patientName, Named("studyDate")=studyDate, Named("echoTime")=echoTime, Named("repetitionTime")=repetitionTime, Named("echoNumber")=echoNumber, Named("phase")=phase, Named("stringsAsFactors")=false);
+            DataFrame info = DataFrame::create(Named("rootPath")=path, Named("seriesNumber")=seriesNumber, Named("seriesDescription")=seriesDescription, Named("patientName")=patientName, Named("studyDate")=studyDate, Named("echoTime")=echoTime, Named("repetitionTime")=repetitionTime, Named("echoNumber")=echoNumber, Named("phase")=phase, Named("gantryTilt")=gantryTilt, Named("stringsAsFactors")=false);
             info.attr("descriptions") = descriptions;
             info.attr("paths") = paths;
             info.attr("class") = CharacterVector::create("divest","data.frame");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ BEGIN_RCPP
 END_RCPP
 }
 
-RcppExport SEXP readDirectory (SEXP path_, SEXP flipY_, SEXP verbosity_, SEXP scanOnly_)
+RcppExport SEXP readDirectory (SEXP path_, SEXP flipY_, SEXP verbosity_, SEXP scanOnly_, SEXP tiltCorrect_)
 {
 BEGIN_RCPP
     const std::string path = as<std::string>(path_);
@@ -26,7 +26,7 @@ BEGIN_RCPP
     options.isFlipY = as<bool>(flipY_);
     options.isCreateBIDS = false;
     options.isCreateText = false;
-    options.isTiltCorrect = false;
+    options.isTiltCorrect = as<bool>(tiltCorrect_);
     options.isRGBplanar = false;
     options.isOnlySingleFile = false;
     options.isForceStackSameSeries = false;


### PR DESCRIPTION
I see `options.isTiltCorrect = false`, which is crucial for CT scans with gantry tilt.  

I have added this option to `readDicom`, but this is problematic as the rows of `scanDicom` no longer match one-to-one when tilt is present.  I am trying to figure out how to adapt this using `scanDicom` and any help is appreciated.

