### PR TITLE
Fix linking to zlib

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,5 +1,5 @@
 PKG_CPPFLAGS = -DUSING_R -DmyDisableMiniZ @JPEG2K_FLAGS@ @FUNCDEFS@ -I. -Idcm2niix -Iujpeg
-PKG_LIBS = @JPEG2K_LIBS@
+PKG_LIBS = @JPEG2K_LIBS@ -lz
 
 OBJECTS_LIBS = ujpeg/ujpeg.o
 


### PR DESCRIPTION
You are calling zlib so you need to link to it.

This fixes cross compilation: https://github.com/r-universe/jonclayden/actions/runs/7494382830/job/20402292548


```Undefined symbols for architecture arm64:
  "_compressBound", referenced from:
      mz_compressBound(unsigned long) in nii_dicom_batch.o
      writeNiiGz(char*, nifti_1_header, unsigned char*, unsigned long, int, bool) in nii_dicom_batch.o
     (maybe you meant: mz_compressBound(unsigned long))
  "_crc32", referenced from:
      mz_crc32(unsigned long, unsigned char const*, unsigned long) in nii_dicom_batch.o
      writeNiiGz(char*, nifti_1_header, unsigned char*, unsigned long, int, bool) in nii_dicom_batch.o
     (maybe you meant: mz_crc32(unsigned long, unsigned char const*, unsigned long), mz_crc32X(unsigned char*, unsigned long) )
  "_deflate", referenced from:
      writeNiiGz(char*, nifti_1_header, unsigned char*, unsigned long, int, bool) in nii_dicom_batch.o
  "_deflateEnd", referenced from:
      writeNiiGz(char*, nifti_1_header, unsigned char*, unsigned long, int, bool) in nii_dicom_batch.o
  "_deflateInit_", referenced from:
      writeNiiGz(char*, nifti_1_header, unsigned char*, unsigned long, int, bool) in nii_dicom_batch.o
  "_inflate", referenced from:
      geProtocolBlock(char const*, int, int, int, int*, int*, int*, int*, float*, char*, char*) in nii_dicom_batch.o
  "_inflateInit2_", referenced from:
      geProtocolBlock(char const*, int, int, int, int*, int*, int*, int*, float*, char*, char*) in nii_dicom_batch.o
ld: symbol(s) not found for architecture arm64
```